### PR TITLE
Allow auto-release job to create releases

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -6,6 +6,8 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Auto-release is failing currently https://github.com/chime/mani-diffy/actions/runs/16507739299.
According to the docs[^1], `contents: write` permission is required.

[^1]: https://github.com/softprops/action-gh-release/blob/f2352b97da0095b4dbbd885a81023e3deabf4fef/README.md?plain=1#L231-L238